### PR TITLE
docs: add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# telepatia-ai-techtest-frontend
+# Telepatía AI Tech Test Frontend
+
+Pequeña aplicación web en Flutter para interactuar con el pipeline de Telepatía AI.
+
+## Requisitos
+
+- [Flutter](https://flutter.dev) 3.7 o superior
+- Navegador Chrome
+
+## Variables de entorno
+
+1. Copia el archivo de ejemplo y renómbralo:
+   ```bash
+   cp telepatia_ai_techtest_frontend/.env.example telepatia_ai_techtest_frontend/.env
+   ```
+2. Edita `telepatia_ai_techtest_frontend/.env` y completa los valores necesarios:
+   ```bash
+   API_BASE_URL=http://127.0.0.1:5005/telepatia-ai-techtest-hfunes/us-central1
+   PROJECT_ID=<tu-project-id>
+   ```
+3. Carga las variables antes de ejecutar la app:
+   ```bash
+   cd telepatia_ai_techtest_frontend
+   source .env
+   ```
+
+## Ejecución local
+
+Dentro de la carpeta `telepatia_ai_techtest_frontend` ejecuta:
+```bash
+./run-local.sh
+```
+El script instalará dependencias y levantará la aplicación en Chrome.
+

--- a/telepatia_ai_techtest_frontend/.env.example
+++ b/telepatia_ai_techtest_frontend/.env.example
@@ -1,0 +1,6 @@
+# URL base del backend de funciones
+API_BASE_URL=http://127.0.0.1:5005/telepatia-ai-techtest-hfunes/us-central1
+
+# ID de tu proyecto de Google Cloud (para entornos de producción)
+PROJECT_ID=
+

--- a/telepatia_ai_techtest_frontend/.gitignore
+++ b/telepatia_ai_techtest_frontend/.gitignore
@@ -1,4 +1,6 @@
 # Miscellaneous
+# Environment variables
+.env
 *.class
 *.log
 *.pyc
@@ -47,3 +49,4 @@ app.*.map.json
 /windows/
 /web/
 /build
+


### PR DESCRIPTION
## Summary
- document local setup and execution
- provide example environment variables
- ignore local .env files

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f30f0d04832ca7c279086670aa9c