### PR TITLE
Add critical frontend unit tests

### DIFF
--- a/telepatia_ai_techtest_frontend/test/api_client_test.dart
+++ b/telepatia_ai_techtest_frontend/test/api_client_test.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:telepatia_ai_techtest_frontend/api/client.dart';
+
+void main() {
+  group('ApiClient.pipelineFromText', () {
+    test('returns decoded json on success', () async {
+      final mock = MockClient((request) async {
+        expect(request.url.toString(), 'http://localhost/pipeline');
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(body['input']['text'], 'hola');
+        return http.Response('{"ok": true}', 200);
+      });
+
+      final client = ApiClient(baseUrl: 'http://localhost', httpClient: mock);
+      final res = await client.pipelineFromText(text: 'hola');
+      expect(res['ok'], true);
+    });
+
+    test('throws ApiException on http error', () async {
+      final mock = MockClient((request) async {
+        return http.Response('ups', 500);
+      });
+
+      final client = ApiClient(baseUrl: 'http://localhost', httpClient: mock);
+      expect(
+        () => client.pipelineFromText(text: 'hola'),
+        throwsA(isA<ApiException>()),
+      );
+    });
+  });
+}
+

--- a/telepatia_ai_techtest_frontend/test/pipeline_provider_test.dart
+++ b/telepatia_ai_techtest_frontend/test/pipeline_provider_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:telepatia_ai_techtest_frontend/providers/pipeline_provider.dart';
+
+void main() {
+  test('nextCorrelationId increments sequentially', () {
+    final provider = PipelineProvider.local();
+    expect(provider.nextCorrelationId(), 'ui-corr-001');
+    expect(provider.nextCorrelationId(), 'ui-corr-002');
+  });
+
+  test('runFromText with empty string sets error state', () async {
+    final provider = PipelineProvider.local();
+    await provider.runFromText(text: '');
+    expect(provider.isError, true);
+    expect(provider.errorMessage, 'El texto no puede estar vacío.');
+  });
+
+  test('runFromAudioUrl with empty url sets error state', () async {
+    final provider = PipelineProvider.local();
+    await provider.runFromAudioUrl(url: '');
+    expect(provider.isError, true);
+    expect(provider.errorMessage, 'La URL no puede estar vacía.');
+  });
+}
+

--- a/telepatia_ai_techtest_frontend/test/widget_test.dart
+++ b/telepatia_ai_techtest_frontend/test/widget_test.dart
@@ -5,26 +5,14 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:telepatia_ai_techtest_frontend/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Home screen renders diagnosis section', (WidgetTester tester) async {
+    await tester.pumpWidget(const TelepatiaApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Diagnóstico desde texto'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- fix widget test to use actual Telepatía home screen
- add ApiClient tests for successful and failed responses
- cover PipelineProvider validation and correlation ID logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0f255ff0832c945eceb3f71dd02b