### PR TITLE
Translate fixed frontend text to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,34 @@
 # Telepatía AI Tech Test Frontend
 
-Pequeña aplicación web en Flutter para interactuar con el pipeline de Telepatía AI.
+Small Flutter web application to interact with the Telepatía AI pipeline.
 
-## Requisitos
+## Requirements
 
-- [Flutter](https://flutter.dev) 3.7 o superior
-- Navegador Chrome
+- [Flutter](https://flutter.dev) 3.7 or higher
+- Chrome browser
 
-## Variables de entorno
+## Environment variables
 
-1. Copia el archivo de ejemplo y renómbralo:
+1. Copy the example file and rename it:
    ```bash
    cp telepatia_ai_techtest_frontend/.env.example telepatia_ai_techtest_frontend/.env
    ```
-2. Edita `telepatia_ai_techtest_frontend/.env` y completa los valores necesarios:
+2. Edit `telepatia_ai_techtest_frontend/.env` and fill in the required values:
    ```bash
    API_BASE_URL=http://127.0.0.1:5005/telepatia-ai-techtest-hfunes/us-central1
-   PROJECT_ID=<tu-project-id>
+   PROJECT_ID=<your-project-id>
    ```
-3. Carga las variables antes de ejecutar la app:
+3. Load the variables before running the app:
    ```bash
    cd telepatia_ai_techtest_frontend
    source .env
    ```
 
-## Ejecución local
+## Local run
 
-Dentro de la carpeta `telepatia_ai_techtest_frontend` ejecuta:
+Inside the `telepatia_ai_techtest_frontend` folder run:
 ```bash
 ./run-local.sh
 ```
-El script instalará dependencias y levantará la aplicación en Chrome.
+The script will install dependencies and launch the application in Chrome.
 

--- a/telepatia_ai_techtest_frontend/lib/api/client.dart
+++ b/telepatia_ai_techtest_frontend/lib/api/client.dart
@@ -1,18 +1,18 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 
-/// Configuración de endpoints del backend (Firebase Functions v2).
+/// Configuration for backend endpoints (Firebase Functions v2).
 class ApiConfig {
-  /// URL base local del emulador (ajustada a lo que usaste en backend).
+  /// Local base URL for the emulator (adjust to match your backend).
   static const String baseUrlLocal =
       "http://127.0.0.1:5005/telepatia-ai-techtest-hfunes/us-central1";
 
-  /// URL base en producción (reemplaza <tu-proyecto> por tu GCP projectId).
+  /// Production base URL (replace <your-project> with your GCP projectId).
   static const String baseUrlProd =
-      "https://us-central1-<tu-proyecto>.cloudfunctions.net";
+      "https://us-central1-<your-project>.cloudfunctions.net";
 }
 
-/// Cliente HTTP simple para hablar con el pipeline del backend.
+/// Simple HTTP client to communicate with the backend pipeline.
 class ApiClient {
   final String baseUrl;
   final http.Client _http;
@@ -20,15 +20,15 @@ class ApiClient {
   ApiClient({required this.baseUrl, http.Client? httpClient})
     : _http = httpClient ?? http.Client();
 
-  /// Llama al pipeline con texto plano.
+  /// Calls the pipeline with plain text.
   ///
   /// POST {baseUrl}/pipeline
   /// body:
   /// {
   ///   "input": {
-  ///     "text": "<texto>",
+  ///     "text": "<text>",
   ///     "language": "es-AR",
-  ///     "correlationId": "opcional"
+  ///     "correlationId": "optional"
   ///   }
   /// }
   Future<Map<String, dynamic>> pipelineFromText({
@@ -54,7 +54,7 @@ class ApiClient {
     if (res.statusCode < 200 || res.statusCode >= 300) {
       throw ApiException(
         message:
-            "Error ${res.statusCode} al llamar pipelineFromText: ${res.body}",
+            "Error ${res.statusCode} calling pipelineFromText: ${res.body}",
         statusCode: res.statusCode,
         body: res.body,
       );
@@ -63,16 +63,16 @@ class ApiClient {
     return _decodeJson(res.body);
   }
 
-  /// Llama al pipeline con audio codificado en Base64.
+  /// Calls the pipeline with audio encoded in Base64.
   ///
   /// POST {baseUrl}/pipeline
   /// body:
   /// {
   ///   "input": {
   ///     "audio": {"type": "base64", "value": "<B64>"},
-  ///     "filename": "archivo.ogg",
+  ///     "filename": "file.ogg",
   ///     "language": "es-AR",
-  ///     "correlationId": "opcional"
+  ///     "correlationId": "optional"
   ///   }
   /// }
   Future<Map<String, dynamic>> pipelineFromAudioBase64({
@@ -100,7 +100,7 @@ class ApiClient {
     if (res.statusCode < 200 || res.statusCode >= 300) {
       throw ApiException(
         message:
-            "Error ${res.statusCode} al llamar pipelineFromAudioBase64: ${res.body}",
+            "Error ${res.statusCode} calling pipelineFromAudioBase64: ${res.body}",
         statusCode: res.statusCode,
         body: res.body,
       );
@@ -109,16 +109,16 @@ class ApiClient {
     return _decodeJson(res.body);
   }
 
-  /// NUEVO: Llama al pipeline con audio por URL pública (mp3/ogg/wav, etc.)
+  /// NEW: Calls the pipeline with audio via public URL (mp3/ogg/wav, etc.)
   ///
   /// POST {baseUrl}/pipeline
   /// body:
   /// {
   ///   "input": {
   ///     "audio": {"type": "url", "value": "<URL>"},
-  ///     "filename": "opcional",
+  ///     "filename": "optional",
   ///     "language": "es-AR",
-  ///     "correlationId": "opcional"
+  ///     "correlationId": "optional"
   ///   }
   /// }
   Future<Map<String, dynamic>> pipelineFromAudioUrl({
@@ -146,7 +146,7 @@ class ApiClient {
     if (res.statusCode < 200 || res.statusCode >= 300) {
       throw ApiException(
         message:
-            "Error ${res.statusCode} al llamar pipelineFromAudioUrl: ${res.body}",
+            "Error ${res.statusCode} calling pipelineFromAudioUrl: ${res.body}",
         statusCode: res.statusCode,
         body: res.body,
       );
@@ -155,7 +155,7 @@ class ApiClient {
     return _decodeJson(res.body);
   }
 
-  /// Cierra el cliente HTTP (usá esto si creás/descartás instancias dinámicamente).
+  /// Closes the HTTP client (use this if you create/discard instances dynamically).
   void dispose() {
     _http.close();
   }
@@ -166,14 +166,14 @@ class ApiClient {
       return decoded;
     }
     throw ApiException(
-      message: "Respuesta inesperada del servidor (no es JSON objeto).",
+      message: "Unexpected server response (not a JSON object).",
       statusCode: 200,
       body: body,
     );
   }
 }
 
-/// Excepción simple para errores de API.
+/// Simple exception for API errors.
 class ApiException implements Exception {
   final String message;
   final int? statusCode;

--- a/telepatia_ai_techtest_frontend/lib/main.dart
+++ b/telepatia_ai_techtest_frontend/lib/main.dart
@@ -14,8 +14,8 @@ class TelepatiaApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
-        // Usamos el backend local por ahora. Para prod:
-        // ChangeNotifierProvider(create: (_) => PipelineProvider.prod("<tu-project-id>")),
+        // Using the local backend for now. For production:
+        // ChangeNotifierProvider(create: (_) => PipelineProvider.prod("<your-project-id>")),
         ChangeNotifierProvider(create: (_) => PipelineProvider.local()),
       ],
       child: MaterialApp(

--- a/telepatia_ai_techtest_frontend/lib/providers/pipeline_provider.dart
+++ b/telepatia_ai_techtest_frontend/lib/providers/pipeline_provider.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import '../api/client.dart';
 
-/// Estados simples del provider para manejar el ciclo de llamada.
+/// Simple provider states to manage the call lifecycle.
 enum PipelineStatus { idle, loading, success, error }
 
 class PipelineProvider extends ChangeNotifier {
@@ -13,7 +13,7 @@ class PipelineProvider extends ChangeNotifier {
   PipelineStatus _status = PipelineStatus.idle;
   String? _errorMessage;
 
-  /// Respuesta cruda del backend (la guardamos como Map para mostrarlo fácil en la UI).
+  /// Raw response from the backend (stored as a Map for easy display in the UI).
   Map<String, dynamic>? _lastResponse;
 
   PipelineProvider.local() : _api = ApiClient(baseUrl: ApiConfig.baseUrlLocal);
@@ -37,14 +37,14 @@ class PipelineProvider extends ChangeNotifier {
     return 'ui-corr-${_correlationCounter.toString().padLeft(3, '0')}';
   }
 
-  /// Llama al pipeline con texto plano.
+  /// Calls the pipeline with plain text.
   Future<void> runFromText({
     required String text,
     String language = "es-AR",
     String? correlationId,
   }) async {
     if (text.trim().isEmpty) {
-      _setError("El texto no puede estar vacío.");
+      _setError("Text cannot be empty.");
       return;
     }
     _setLoading();
@@ -54,7 +54,7 @@ class PipelineProvider extends ChangeNotifier {
         language: language,
         correlationId: correlationId,
       );
-      // Logs útiles en dev:
+      // Useful logs in dev:
       // print("API keys -> ${res.keys.toList()}");
       // print("Diagnosis present? ${res['diagnosis'] != null}");
       _setSuccess(res);
@@ -63,7 +63,7 @@ class PipelineProvider extends ChangeNotifier {
     }
   }
 
-  /// Llama al pipeline con audio base64 (UI opcional).
+  /// Calls the pipeline with base64 audio (optional UI).
   Future<void> runFromAudioBase64({
     required String base64Audio,
     required String filename,
@@ -71,11 +71,11 @@ class PipelineProvider extends ChangeNotifier {
     String? correlationId,
   }) async {
     if (base64Audio.trim().isEmpty) {
-      _setError("El audio base64 no puede estar vacío.");
+      _setError("Base64 audio cannot be empty.");
       return;
     }
     if (filename.trim().isEmpty) {
-      _setError("El filename no puede estar vacío.");
+      _setError("Filename cannot be empty.");
       return;
     }
     _setLoading();
@@ -92,7 +92,7 @@ class PipelineProvider extends ChangeNotifier {
     }
   }
 
-  /// NUEVO: Llama al pipeline con audio por URL pública (mp3/ogg/wav, etc.)
+  /// NEW: Calls the pipeline with audio via public URL (mp3/ogg/wav, etc.)
   Future<void> runFromAudioUrl({
     required String url,
     String? filename,
@@ -100,7 +100,7 @@ class PipelineProvider extends ChangeNotifier {
     String? correlationId,
   }) async {
     if (url.trim().isEmpty) {
-      _setError("La URL no puede estar vacía.");
+      _setError("URL cannot be empty.");
       return;
     }
     _setLoading();
@@ -117,7 +117,7 @@ class PipelineProvider extends ChangeNotifier {
     }
   }
 
-  /// Helper para formatear cualquier Map/JSON bonito en la UI.
+  /// Helper to pretty-format any Map/JSON in the UI.
   String prettyJson([Object? data]) {
     try {
       if (data == null) return "{}";

--- a/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
+++ b/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
@@ -12,15 +12,15 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  // Estado para TEXT → pipeline
+  // State for TEXT → pipeline
   final _textController = TextEditingController(
     text:
-        "Me estoy sintiendo un poco mal, me duele la cabeza y tengo mucho moco.",
+        "I'm feeling a bit unwell; my head hurts and I have a lot of mucus.",
   );
 
-  // Estado para AUDIO → URL
+  // State for AUDIO → URL
   final _audioUrlController = TextEditingController();
-  String? _audioFilename; // opcional, lo podés inferir desde la URL
+  String? _audioFilename; // optional, you can infer it from the URL
 
   @override
   void dispose() {
@@ -102,13 +102,13 @@ class _HomeScreenState extends State<HomeScreen> {
           constraints: const BoxConstraints(maxWidth: 900),
           child: Padding(
             padding: const EdgeInsets.all(16.0),
-            // Habilita selección de texto en toda la pantalla:
+            // Enable text selection on the entire screen:
             child: SelectionArea(
               child: ListView(
                 children: [
                   const SizedBox(height: 8),
                   Text(
-                    "Diagnóstico desde texto",
+                    "Diagnosis from text",
                     style: Theme.of(context).textTheme.titleLarge,
                   ),
                   const SizedBox(height: 12),
@@ -117,8 +117,9 @@ class _HomeScreenState extends State<HomeScreen> {
                     maxLines: 3,
                     decoration: const InputDecoration(
                       border: OutlineInputBorder(),
-                      labelText: 'Describe tus síntomas (texto)',
-                      hintText: 'Ej: Me duele la cabeza y tengo mucho moco...',
+                      labelText: 'Describe your symptoms (text)',
+                      hintText:
+                          'E.g., My head hurts and I have a lot of mucus...',
                     ),
                   ),
                   const SizedBox(height: 12),
@@ -141,25 +142,25 @@ class _HomeScreenState extends State<HomeScreen> {
                       icon: const Icon(Icons.medical_services),
                       label:
                           provider.isLoading
-                              ? const Text("Procesando…")
-                              : const Text("Diagnosticar"),
+                              ? const Text("Processing…")
+                              : const Text("Diagnose"),
                     ),
                   ),
 
                   // ==========================
-                  // Sección: Diagnóstico desde AUDIO (URL)
+                  // Section: Diagnosis from AUDIO (URL)
                   // ==========================
                   const SizedBox(height: 28),
                   const Divider(),
                   const SizedBox(height: 8),
                   Text(
-                    "Diagnóstico desde audio (URL)",
+                    "Diagnosis from audio (URL)",
                     style: Theme.of(context).textTheme.titleLarge,
                   ),
                   const SizedBox(height: 12),
                   Text(
-                    "Pegá el enlace público a tu audio (.ogg, .mp3, .wav, etc.). "
-                    "Usaremos la URL directa para transcribir y diagnosticar.",
+                    "Paste the public link to your audio (.ogg, .mp3, .wav, etc.). "
+                    "We'll use the direct URL to transcribe and diagnose.",
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                   const SizedBox(height: 12),
@@ -168,17 +169,17 @@ class _HomeScreenState extends State<HomeScreen> {
                     controller: _audioUrlController,
                     decoration: InputDecoration(
                       border: const OutlineInputBorder(),
-                      labelText: 'URL del audio',
-                      hintText: 'https://.../mi_audio.ogg',
+                      labelText: 'Audio URL',
+                      hintText: 'https://.../my_audio.ogg',
                       errorText:
                           audioUrl.isEmpty || isAudioUrlValid
                               ? null
-                              : 'Ingresá una URL válida (http/https).',
+                              : 'Enter a valid URL (http/https).',
                       suffixIcon:
                           audioUrl.isEmpty
                               ? null
                               : IconButton(
-                                tooltip: "Limpiar",
+                                tooltip: "Clear",
                                 onPressed:
                                     provider.isLoading
                                         ? null
@@ -202,7 +203,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   if (_audioFilename != null) ...[
                     const SizedBox(height: 8),
                     Text(
-                      "Nombre inferido: ${_audioFilename!}",
+                      "Inferred name: ${_audioFilename!}",
                       style: Theme.of(context).textTheme.bodySmall,
                     ),
                   ],
@@ -229,14 +230,14 @@ class _HomeScreenState extends State<HomeScreen> {
                                             provider.nextCorrelationId(),
                                       );
                                 } catch (e) {
-                                  _showSnack('No se pudo enviar el audio: $e');
+                                  _showSnack('Could not send audio: $e');
                                 }
                               },
                       icon: const Icon(Icons.link),
                       label:
                           provider.isLoading
-                              ? const Text("Procesando audio…")
-                              : const Text("Diagnosticar desde URL"),
+                              ? const Text("Processing audio…")
+                              : const Text("Diagnose from URL"),
                     ),
                   ),
 
@@ -255,7 +256,7 @@ class _HomeScreenState extends State<HomeScreen> {
                       child: Padding(
                         padding: const EdgeInsets.all(12.0),
                         child: Text(
-                          provider.errorMessage ?? "Error desconocido",
+                          provider.errorMessage ?? "Unknown error",
                           style: TextStyle(
                             color:
                                 Theme.of(context).colorScheme.onErrorContainer,
@@ -280,7 +281,7 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  /// Formatea bytes en B/KB/MB/GB.
+  /// Formats bytes into B/KB/MB/GB.
   String _formatBytes(int bytes, [int decimals = 1]) {
     if (bytes <= 0) return "0 B";
     const k = 1024;
@@ -299,10 +300,10 @@ class _ResultBlock extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Campos esperados:
+    // Expected fields:
     final transcript = data["transcript"];
     final extracted = data["extracted"];
-    // Backend actual usa "diagnosis"; toleramos "diagnose" por compatibilidad:
+    // Current backend uses "diagnosis"; tolerate "diagnose" for compatibility:
     final diagnosis =
         (data["diagnosis"] ?? data["diagnose"]) as Map<String, dynamic>?;
     final timings =
@@ -318,7 +319,7 @@ class _ResultBlock extends StatelessWidget {
         Text("Diagnosis", style: Theme.of(context).textTheme.titleLarge),
         const SizedBox(height: 8),
 
-        // ======= BLOQUE DIAGNÓSTICO PRINCIPAL =======
+        // ======= MAIN DIAGNOSIS BLOCK =======
         if (diagnosis != null) ...[
           Card(
             child: Padding(
@@ -408,12 +409,12 @@ class _ResultBlock extends StatelessWidget {
             ),
           ),
 
-        // Fallback: si no hay nada reconocible, mostramos todo:
+        // Fallback: if there's nothing recognizable, show everything:
         if (transcript == null && extracted == null && diagnosis == null) ...[
           Card(
             child: Padding(
               padding: const EdgeInsets.all(12.0),
-              child: SelectableText("Respuesta completa:\n${pretty(data)}"),
+              child: SelectableText("Full response:\n${pretty(data)}"),
             ),
           ),
         ],
@@ -444,21 +445,21 @@ class _DiagnosisView extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (summary != null) ...[
-          SelectableText("Resumen", style: bold),
+          SelectableText("Summary", style: bold),
           const SizedBox(height: 4),
           SelectableText(summary, style: normal),
           const SizedBox(height: 12),
         ],
 
         if (severity != null) ...[
-          SelectableText("Severidad", style: bold),
+          SelectableText("Severity", style: bold),
           const SizedBox(height: 4),
           SelectableText(severity, style: normal),
           const SizedBox(height: 12),
         ],
 
         if (differentials.isNotEmpty) ...[
-          SelectableText("Diferenciales", style: bold),
+          SelectableText("Differentials", style: bold),
           const SizedBox(height: 4),
           SelectableText(
             differentials.map((e) => "• $e").join("\n"),
@@ -468,7 +469,7 @@ class _DiagnosisView extends StatelessWidget {
         ],
 
         if (recommendations.isNotEmpty) ...[
-          SelectableText("Recomendaciones", style: bold),
+          SelectableText("Recommendations", style: bold),
           const SizedBox(height: 4),
           SelectableText(
             recommendations.map((e) => "• $e").join("\n"),

--- a/telepatia_ai_techtest_frontend/lib/utils/web_file_picker.dart
+++ b/telepatia_ai_techtest_frontend/lib/utils/web_file_picker.dart
@@ -1,14 +1,14 @@
 // lib/utils/web_file_picker.dart
-// File picker exclusivo para Flutter Web (usa dart:html).
+// File picker exclusive to Flutter Web (uses dart:html).
 import 'dart:async';
 import 'dart:html' as html;
 import 'dart:math' as math;
 
-/// Resultado al elegir un archivo
+/// Result when picking a file
 class PickedWebFile {
   final String filename;
   final int sizeBytes;
-  final String base64; // SOLO el payload base64 (sin "data:...;base64,")
+  final String base64; // ONLY the base64 payload (without "data:...;base64,")
 
   PickedWebFile({
     required this.filename,
@@ -17,9 +17,9 @@ class PickedWebFile {
   });
 }
 
-/// Lanza un <input type="file"> y devuelve el archivo como Base64 (sin prefijo).
-/// [accept] por ejemplo: "audio/*" o "audio/ogg".
-/// [maxBytes] para limitar tamaño (por defecto 15 MB).
+/// Opens an <input type="file"> and returns the file as Base64 (without prefix).
+/// [accept] e.g. "audio/*" or "audio/ogg".
+/// [maxBytes] to limit size (default 15 MB).
 Future<PickedWebFile?> pickSingleFileAsBase64({
   String accept = '*/*',
   int maxBytes = 15 * 1024 * 1024,
@@ -40,17 +40,17 @@ Future<PickedWebFile?> pickSingleFileAsBase64({
       }
       final file = input.files!.first;
 
-      final name = file.name ?? 'archivo';
+      final name = file.name ?? 'file';
       final size = file.size ?? 0;
 
       if (size <= 0) {
-        completer.completeError(StateError('El archivo está vacío.'));
+        completer.completeError(StateError('The file is empty.'));
         return;
       }
       if (size > maxBytes) {
         completer.completeError(
           StateError(
-            'El archivo supera el máximo permitido (${_fmtBytes(maxBytes)}). Tamaño: ${_fmtBytes(size)}',
+            'The file exceeds the maximum allowed (${_fmtBytes(maxBytes)}). Size: ${_fmtBytes(size)}',
           ),
         );
         return;
@@ -61,7 +61,7 @@ Future<PickedWebFile?> pickSingleFileAsBase64({
 
       reader.onError.first.then((_) {
         if (!completer.isCompleted) {
-          completer.completeError(StateError('No se pudo leer el archivo.'));
+          completer.completeError(StateError('Could not read the file.'));
         }
       });
 
@@ -69,11 +69,11 @@ Future<PickedWebFile?> pickSingleFileAsBase64({
         try {
           final result = reader.result?.toString() ?? '';
           if (result.isEmpty || !result.contains(',')) {
-            throw StateError('Formato de DataURL inválido.');
+            throw StateError('Invalid DataURL format.');
           }
           final base64Payload = result.split(',').last.trim();
           if (base64Payload.isEmpty) {
-            throw StateError('Payload base64 vacío.');
+            throw StateError('Empty base64 payload.');
           }
           completer.complete(
             PickedWebFile(

--- a/telepatia_ai_techtest_frontend/test/widget_test.dart
+++ b/telepatia_ai_techtest_frontend/test/widget_test.dart
@@ -1,30 +1,12 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:telepatia_ai_techtest_frontend/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  testWidgets('shows app bar title', (WidgetTester tester) async {
+    await tester.pumpWidget(const TelepatiaApp());
+    expect(find.text('Doctor Helper'), findsOneWidget);
   });
 }
+


### PR DESCRIPTION
## Summary
- translate home screen labels, hints, and errors to English
- update utility, provider, and API client messages to English
- document English environment setup and adjust widget test

## Testing
- `dart format .` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0fc69c38832cafed54b593948f40