### PR TITLE
Format API responses as nested bullet lists

### DIFF
--- a/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
+++ b/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/pipeline_provider.dart';
+import '../utils/bullet_list.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -245,12 +246,14 @@ class _HomeScreenState extends State<HomeScreen> {
                       color: Theme.of(context).colorScheme.errorContainer,
                       child: Padding(
                         padding: const EdgeInsets.all(12.0),
-                        child: Text(
-                          provider.errorMessage ?? "Unknown error",
+                        child: DefaultTextStyle(
                           style: TextStyle(
-                            color:
-                                Theme.of(context).colorScheme.onErrorContainer,
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onErrorContainer,
                           ),
+                          child: buildBulletList(
+                              provider.error ?? {"message": "Unknown error"}),
                         ),
                       ),
                     ),
@@ -357,7 +360,7 @@ class _ResultBlock extends StatelessWidget {
                                         style: bold,
                                       ),
                                       const SizedBox(height: 4),
-                                      SelectableText(pretty(timings)),
+                                      buildBulletList(timings),
                                     ],
                                   ),
                                 ),
@@ -396,7 +399,7 @@ class _ResultBlock extends StatelessWidget {
                                     children: [
                                       SelectableText("Extracted:", style: bold),
                                       const SizedBox(height: 4),
-                                      SelectableText(pretty(extracted)),
+                                      buildBulletList(extracted),
                                     ],
                                   ),
                                 ),

--- a/telepatia_ai_techtest_frontend/lib/utils/bullet_list.dart
+++ b/telepatia_ai_techtest_frontend/lib/utils/bullet_list.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/widgets.dart';
+
+/// Recursively builds a bullet list widget for maps and lists.
+Widget buildBulletList(dynamic data) {
+  return _build(data);
+}
+
+Widget _build(dynamic data) {
+  if (data is Map) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final entry in data.entries)
+          _bulletRow(
+            (entry.value is Map || entry.value is List)
+                ? Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('${entry.key}:'),
+                      Padding(
+                        padding: const EdgeInsets.only(left: 16),
+                        child: _build(entry.value),
+                      ),
+                    ],
+                  )
+                : Text('${entry.key}: ${entry.value}'),
+          ),
+      ],
+    );
+  } else if (data is List) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final item in data) _bulletRow(_build(item)),
+      ],
+    );
+  } else {
+    return Text(data.toString());
+  }
+}
+
+Widget _bulletRow(Widget child) {
+  return Row(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      const Text('• '),
+      Expanded(child: child),
+    ],
+  );
+}

--- a/telepatia_ai_techtest_frontend/test/pipeline_provider_test.dart
+++ b/telepatia_ai_techtest_frontend/test/pipeline_provider_test.dart
@@ -13,13 +13,13 @@ void main() {
     final provider = PipelineProvider.withDefaultApi();
     await provider.runFromText(text: '');
     expect(provider.isError, true);
-    expect(provider.errorMessage, 'El texto no puede estar vacío.');
+    expect(provider.error?["message"], 'Text cannot be empty.');
   });
 
   test('runFromAudioUrl with empty url sets error state', () async {
     final provider = PipelineProvider.withDefaultApi();
     await provider.runFromAudioUrl(url: '');
     expect(provider.isError, true);
-    expect(provider.errorMessage, 'La URL no puede estar vacía.');
+    expect(provider.error?["message"], 'URL cannot be empty.');
   });
 }


### PR DESCRIPTION
## Summary
- Format API errors into structured bullet lists
- Render timing and extracted metrics using nested bullets
- Update provider tests for new error structure
- Translate empty-input error messages to English

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/providers/pipeline_provider.dart test/pipeline_provider_test.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3ee01674832c8c2a75da69f923d3