### PR TITLE
fix: adjust Telepatía logo width

### DIFF
--- a/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
+++ b/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
@@ -82,7 +82,7 @@ class _HomeScreenState extends State<HomeScreen> {
       appBar: AppBar(
         title: Row(
           children: [
-            Image.asset('assets/images/telepatia_logo.png', height: 32),
+            Image.asset('assets/images/telepatia_logo.png', width: 120),
             const SizedBox(width: 8),
             const Text('Doctor Helper'),
           ],


### PR DESCRIPTION
## Summary
- size Telepatía icon explicitly at width 120 to avoid compression

## Testing
- `dart format lib/screens/home_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba52f853c8832cb125560e1d5d264c