### PR TITLE
Restore floating label for symptoms input

### DIFF
--- a/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
+++ b/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
@@ -124,15 +124,12 @@ class _HomeScreenState extends State<HomeScreen> {
                                 .copyWith(color: Colors.white),
                           ),
                           const SizedBox(height: 12),
-                          const Text(
-                            'Symptoms or Audio URL',
-                            style: TextStyle(color: Colors.white),
-                          ),
-                          const SizedBox(height: 12),
                           TextField(
                             controller: _inputController,
                             maxLines: 3,
                             decoration: InputDecoration(
+                              labelText: 'Symptoms or Audio URL',
+                              alignLabelWithHint: true,
                               border: const OutlineInputBorder(),
                               hintText:
                                   'E.g., My head hurts and I have a lot of mucus... or https://.../my_audio.ogg',


### PR DESCRIPTION
## Summary
- restore floating label effect for `Symptoms or Audio URL` by using `labelText`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5415be38832c913c4dcbcec3b406