### PR TITLE
style: set disabled color for Diagnose button

### DIFF
--- a/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
+++ b/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
@@ -176,6 +176,10 @@ class _HomeScreenState extends State<HomeScreen> {
                               style: ElevatedButton.styleFrom(
                                 backgroundColor: const Color(0xFFE5E6F7),
                                 foregroundColor: const Color(0xFF6884F3),
+                                disabledBackgroundColor:
+                                    const Color(0xFFE5E6F7),
+                                disabledForegroundColor:
+                                    const Color(0xFF6884F3),
                               ),
                               onPressed: provider.isLoading || input.isEmpty
                                   ? null


### PR DESCRIPTION
## Summary
- ensure Diagnose button uses #E5E6F7 when disabled

## Testing
- `dart format telepatia_ai_techtest_frontend/lib/screens/home_screen.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ba548d677c832c98a38a9c284dcd96