### PR TITLE
Style disabled Diagnose button in gray

### DIFF
--- a/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
+++ b/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
@@ -172,9 +172,9 @@ class _HomeScreenState extends State<HomeScreen> {
                                 backgroundColor: const Color(0xFFE5E6F7),
                                 foregroundColor: const Color(0xFF6884F3),
                                 disabledBackgroundColor:
-                                    const Color(0xFFE5E6F7),
+                                    const Color(0xFFE0E0E0),
                                 disabledForegroundColor:
-                                    const Color(0xFF6884F3),
+                                    const Color(0xFF808080),
                               ),
                               onPressed: provider.isLoading || input.isEmpty
                                   ? null


### PR DESCRIPTION
## Summary
- make disabled Diagnose button appear in light gray with darker text

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba59660784832c85e58d4184ff4416