### PR TITLE
style: unify diagnosis placeholder styling

### DIFF
--- a/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
+++ b/telepatia_ai_techtest_frontend/lib/screens/home_screen.dart
@@ -131,6 +131,12 @@ class _HomeScreenState extends State<HomeScreen> {
                               border: const OutlineInputBorder(),
                               hintText:
                                   'E.g., My head hurts and I have a lot of mucus... or https://.../my_audio.ogg',
+                              hintStyle: Theme.of(context)
+                                  .textTheme
+                                  .bodyMedium
+                                  ?.copyWith(
+                                    color: const Color(0xFF808080),
+                                  ),
                               errorText: input.isEmpty || !looksLikeUrl || isUrl
                                   ? null
                                   : 'Enter a valid URL (http/https).',


### PR DESCRIPTION
## Summary
- match Diagnosis widget placeholder style to body text and disabled button color

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5a962604832c8d90e2c6ea645cd0