### PR TITLE
docs: add test run section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ Inside the `telepatia_ai_techtest_frontend` folder run:
 ```
 The script will install dependencies and launch the application in Chrome.
 
+## Test run
+
+To execute the Flutter test suite, navigate to the `telepatia_ai_techtest_frontend` directory and run:
+
+```bash
+flutter test
+```
+


### PR DESCRIPTION
## Summary
- document how to execute the project's Flutter tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5dbcd878832c91ff1c82cd071e6e